### PR TITLE
Made H Quine variable

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -232,8 +232,6 @@ def gte(a, b):
     if not isnum(a) and isnum(b):
         return a[b-1:]
     return a >= b
-H = {}
-
 
 # h. int, str, list.
 def head(a):

--- a/pyth.py
+++ b/pyth.py
@@ -25,6 +25,8 @@ sys.setrecursionlimit(100000)
 
 # Parse it!
 def general_parse(code):
+    global H
+    H=code
     code = prepend_parse(code)
     # Parsing
     args_list = []


### PR DESCRIPTION
"H" being the empty dict was pretty useless. There was no way to modify or create dicts. So I made H the quine variable so that it is autoinitialized to the source. That way not only the regular quines, but the modified quine challenges would be a lot easier. And you wouldn't be reading source, it would be a language feature! There was no way to do that in macros.py since it would have to be done at runtime, and I couldn't make it a function like input since it was also the lambda var for reduce. So I edited it to be set to the code inside general_parse. I only did it for pyth.py, not safe_pyth.py, but that should be an easy change. Also, there might be an issue with if the newline should be included with the code, but again, easy change.

Ex: rH1
       RH1