### PR TITLE
Added Augmented Assignment

### DIFF
--- a/extra_parse.py
+++ b/extra_parse.py
@@ -47,3 +47,6 @@ def python_parse(active_char, rest_code):
             output += rest_code[0]
             rest_code = rest_code[1:]
         return output, rest_code[1:]
+
+def augmented_assignment_parse(active_char, rest_code):
+	return rest_code[:2]+active_char+rest_code[1:]

--- a/pyth.py
+++ b/pyth.py
@@ -79,6 +79,10 @@ def parse(code, spacing="\n "):
         return replace_parse(active_char, rest_code, spacing)
     # And for general functions
     if active_char in c_to_f:
+		#Check for augmented assignment
+        if rest_code[0]=="=":
+            return parse(augmented_assignment_parse(active_char, rest_code))
+		#Just a regular function parse
         return function_parse(active_char, rest_code)
     # General format functions/operators
     if active_char in c_to_i:
@@ -205,7 +209,7 @@ def prepend_parse(code):
 # safe infix.
 def add_print(code):
     if len(code) > 0:
-        if (code[0] not in 'p ' and code[0] in c_to_f) or \
+        if (code[0] not in 'p ' and code[0] in c_to_f and code[1]!="=") or \
             code[0] in variables or \
             code[0] in "@&|]}?,\\\".0123456789," or \
             ((code[0] in 'JK' or code[0] in prepend) and


### PR DESCRIPTION
Arbitrary Augmented Assignnment
====================

A big feature missing from Pyth is augmented assignment except for ``~``. However, there is no real reason that this is not so. So, I went and implemented arbitrary augmented assignment. It works because in Pyth an equals sign should never directly follow a function (By function I mean anything listed in ``c_to_f``). Hence, we could fill in that gap of usage to implement augmented assignment in the traditional form (i.e. +=, -=). However, this can be made even more powerful by allowing arbitrary functions in ``c_to_f`` to be used in augmented assignment. This make ``*=`` possible, but also weird ones like ``s=`` or ``:=``.

Examples
------------

Traditional binary operator example:

	==================================================
	*=T3T
	==================================================
	T=copy(times(T,3))
	Pprint("\n",T)
	==================================================
	30

More unusual binary operator example:

	==================================================
	>=T5T
	==================================================
	T=copy(gt(T,5))
	Pprint("\n",T)
	==================================================
	True

Unary operator example:

	==================================================
	KUTs=KK
	==================================================
	K=urange(T)
	K=copy(Psum(K))
	Pprint("\n",K)
	==================================================
	45

Ternary operator example:

	==================================================
	KUT:=K3TK
	==================================================
	K=urange(T)
	K=copy(at_slice(K,3,T))
	Pprint("\n",K)
	==================================================
	[3, 4, 5, 6, 7, 8, 9]

How it works
----------------

It works pretty simply. In the check for ``c_to_f`` in ``parse``, before returning the ``function_parse`` call, I check if ``rest_code`` begins with ``=``. If it does, I use my ``augmented_assignment_parse`` defined in ``extra_parse`` to shuffle ``rest_code`` and ``active_char`` around and recursively call ``parse`` with the new code. I also made a slight change to ``add_print`` so ``general_parse`` does not interpret the non-shuffled code as a direct function call to be printed.

A Slight Problem
---------------------

There is however a slight problem with this approach, in that functions that take the intended variable at the *end* of its arity will not work with this. For example. ``map`` will not realize that the variable to be assigned to needs to be placed at the end of its arg list. This will result in something like this:

	==================================================
	KUTm=K*ddK
	==================================================
	K=urange(T)
	K=copy(Pmap(lambda d:K,times(d,d)))
	Pprint("\n",K)
	==================================================
	[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]

Obviously not what was desired. While this can be remedied by adding an extra value to the ``c_to_f`` tuple, more problems are created and the code gets very messy with multiple statements and all. I just didn't think that a ``m=`` operator has enough utility to warrant that much code re-factoring.