### PR TITLE
Split lists into n pieces

### DIFF
--- a/doc.txt
+++ b/doc.txt
@@ -71,7 +71,9 @@ _ 1 N neg               Negation. Str and list reverse.
 ` 1 N repr              Python repr.
 a 2 N append            Python .append(). First arguement must be a list.
 b 0 N lineBreak         Variable. "\n"
-c 2 N chop              chop str/list every n elements. Also str.split, floating point division.
+c 2 N chop              On <str/list><int> chop str/list every n elements. 
+                        On <int><str/list> split str/list into n pieces (elements are equally distributed).
+						Also str.split, floating point division.
 d 0 N                   Variable. " "
 e 1 N end               %10 or last element.
 f 2 N filter            Implicit lambda, T -> Y -> Z -> . on num, iter.count

--- a/macros.py
+++ b/macros.py
@@ -208,8 +208,7 @@ def chop(a, b=None):
         return a.split(b)
     if b is None:
         return a.split()
-    return list(map(lambda d: a[b*d:b*(d+1)], range(math.ceil(len(a)/b))))
-
+    return [a[i:i+b] for i in range(0, len(a), b)]
 
 # C. int, str.
 def Pchr(a):

--- a/macros.py
+++ b/macros.py
@@ -202,13 +202,25 @@ b = "\n"
 
 # c. All
 def chop(a, b=None):
-    if isnum(a):
+    if isnum(a) and isnum(b):
         return a/b
-    if isinstance(b, str):
+    if isinstance(a, str) and isinstance(b, str):
         return a.split(b)
     if b is None:
         return a.split()
-    return [a[i:i+b] for i in range(0, len(a), b)]
+    # iterable, int -> chop a into pieces of length b
+    if isinstance(a, collections.Iterable) and isnum(b):
+        return [a[i:i+b] for i in range(0, len(a), b)]
+    # int, iterable -> split b into a pieces (distributed equally)
+    else:
+        m = len(b) // a # min number of elements
+        r = len(b) % a  # remainding elements
+        begin,end = 0, m + (r > 0)
+        l = []
+        for i in range(a):
+            l.append(b[begin:end])
+            begin,end = end, end + m + (i+ 1 < r)
+        return l
 
 # C. int, str.
 def Pchr(a):

--- a/web-docs.txt
+++ b/web-docs.txt
@@ -56,7 +56,7 @@ _ 1 N neg Negation. Str and list reverse.
 ` 1 N repr Python repr.
 a 2 N append Python .append(). First arguement must be a list.
 b 0 N line-Break Variable. "\n"
-c 2 N chop chop str/list every n elements. Also str.split, floating point division.
+c 2 N On <str/list><int> chop str/list every n elements. On <int><str/list> split str/list into n pieces (elements are equally distributed). Also str.split, floating point division.chop chop str/list every n elements. Also str.split, floating point division.
 d 0 N d Variable. " "
 e 1 N end %10 or last element.
 f 2 N filter Implicit lambda, T -> Y -> Z -> . on num, iter.count


### PR DESCRIPTION
This implements and closes #26. 

The elements in the list (or string) are equally distributed. `c4U5` will return `[[0, 1], [2], [3]]` and `c5"abc"` will return `['a', 'b', 'c', '', '']`. 