### PR TITLE
Bugfix, substrings didn't work with integer

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -897,7 +897,7 @@ def substrings(a, b):
         raise BadTypeCombinationError(".:", a, b)
     if isinstance(b, int):
         step = b
-    if isinstance(b, float):
+    elif isinstance(b, float):
         step = int(b * len(seq))
     elif is_col(b):
         step = len(b)


### PR DESCRIPTION
[`.:"hallo"2`][1] didn't work, a missing `elif` triggered an `BadTypeCombinationError`. 

Should we create a test suite for Pyth? It's getting quite big lately. 

  [1]: https://pyth.herokuapp.com/?code=.%3A%22hallo%222&debug=0