### PR TITLE
Added write functionality

### DIFF
--- a/data.py
+++ b/data.py
@@ -142,6 +142,7 @@ c_to_f = {
     '.S': ('shuffle', 1),
     '.s': ('stripchars', 2),
     '.t': ('trig', 2),
+    '.w': ('Pwrite', 2),
     '.x': ('product', 1),
     '.z': ('all_input', 0),
     '.^': ('pow', 3),

--- a/macros.py
+++ b/macros.py
@@ -843,8 +843,10 @@ def trig(a, b):
 
 # .w. write
 def Pwrite(a, b="foo.txt"):
-    with open(b, 'w') as f:
-        f.write("\n".join(map(str, a)) if is_seq(a) and not isinstance(a, str) else str(a))
+    if not isinstance(b, str):
+        raise BadTypeCombinationError(".w", a, b)
+    with open(b, 'a') as f:
+        f.write(("\n".join(map(str, a)) if is_seq(a) and not isinstance(a, str) else str(a))+"\n")
 
 # .x. col
 def product(a):

--- a/macros.py
+++ b/macros.py
@@ -841,6 +841,10 @@ def trig(a, b):
 
     return funcs[b](a)
 
+# .w. write
+def Pwrite(a, b="foo.txt"):
+    with open(b, 'w') as f:
+        f.write("\n".join(map(str, a)) if is_seq(a) and not isinstance(a, str) else str(a))
 
 # .x. col
 def product(a):


### PR DESCRIPTION
The "O" part of file I/O was missing and now that we have a bunch more free namespaces, I think it would be a good feature. Very simple, it either takes a seq or an element. Everything is converted to strings and sequences are joined by newlines. Then writes to the second arg which defaults to ``foo.txt``.