### PR TITLE
Added RNG seeding

### DIFF
--- a/doc.txt
+++ b/doc.txt
@@ -139,7 +139,7 @@ z  0 N                   Variable. Autoinitializing to input.
 .S 1 N shuffle           .S<col> random.shuffle(<col>). .S(<int>) = .S(range(<int>))
 .t 2 N trigonometry      Collection of trigonometric functions. See below.
 .u 1 N unpack-close      Shorthand for .*_).
-.x 1 N group-x           product, over a non-str seq. Uses Pyth *.
+.x 1 N group-x           product, over a non-str seq. Uses Pyth *. With num is random.seed.
 .z 0 N all-input         Take all of stdin, return as list of lines.
 .^ 3 N powmod            Python pow(a, b, c).
 .& 2 N bitand            Python bitwise &.

--- a/macros.py
+++ b/macros.py
@@ -856,8 +856,11 @@ def product(a):
         if len(a) == 0:
             return 1
         return reduce(lambda b, c: times(b, c), a[1:], a[0])
+    
+    if is_num(a):
+        return random.seed(a)
 
-    random.seed(a)
+    raise BadTypeCombinationError(".x", a)
 
 # .z. N/A
 def all_input():

--- a/macros.py
+++ b/macros.py
@@ -857,6 +857,7 @@ def product(a):
             return 1
         return reduce(lambda b, c: times(b, c), a[1:], a[0])
 
+    random.seed(a)
 
 # .z. N/A
 def all_input():

--- a/web-docs.txt
+++ b/web-docs.txt
@@ -113,7 +113,7 @@ z 0 N z Variable. Autoinitializing to input.
 .S 1 N shuffle .S<col> random.shuffle(<col>). str out if str in, otherwise list out. .S(<int>) = .S(range(<int>))
 .t 2 N trigonometry Collection of trigonometric functions.
 .u 1 N unpack-close Shorthand for .*_).
-.x 1 N multiply product, over a non-str seq. Uses Pyth *.
+.x 1 N multiply product, over a non-str seq. Uses Pyth *. With num is random.seed.
 .z 0 N all-input Take all of stdin, return as list of lines.
 .^ 3 N powmod Python pow(a, b, c).
 .& 2 N bitand Python bitwise &.


### PR DESCRIPTION
Though not used very often, reproducibility is still comes up a fair amount in randomness challenges and `$random.seed()$` kills your score. I have put it into all non-`seq` of `.x` though it most often will be used with ints. I don't think that such a small part  of the namespace is a big price to pay for seeding.