### PR TITLE
Added Mathematical Constants list

### DIFF
--- a/data.py
+++ b/data.py
@@ -132,6 +132,7 @@ c_to_f = {
     '.l': ('log', 2),
     '.m': ('minimal(lambda b:', 2),
     '.M': ('maximal(lambda Z:', 2),
+    '.n': ('Pnumbers', 1),
     '.O': ('Poct', 1),
     '.p': ('permutations', 1),
     '.P': ('permutations2', 2),

--- a/doc.txt
+++ b/doc.txt
@@ -123,11 +123,12 @@ z  0 N                   Variable. Autoinitializing to input.
 .F 2 N format            a.format(b) - if b is a non-string sequence, it will be unpacked.
 .h 1 N hash
 .H 1 N hex               Hexadecimal string representing _. Direct on int, interpreted as UTF-8 on str.
-.l 2 N log               Python math.log(a, b).
+.l 2 N log               Python math.log(a, b). Default for b is natural log.
 .m 2 N minimal           Filter 2nd arg on elements which give minimal value when 1st arg is aplied.
                          First arg is lambda, b ->
 .M 2 N maximal           Filter 2nd arg on elements which give maximal value when 1st arg is aplied.
                          First arg is lambda, Z ->
+.n 1 N Numbers           List of mathematical constants: pi, e, sqrt(2), phi, infinity
 .N 1 Y The one after M   def :(N, T, Y): return _.
 .O 1 N oct               Octal string representing _. Direct on int, interpreted as UTF-8 on str.
 .p 1 N permutations      itertools.permutations(_).

--- a/macros.py
+++ b/macros.py
@@ -783,10 +783,10 @@ def maximal(a, b):
 
 # .n. mathematical constants
 def Pnumbers(a):
-    if a<5:
+    if a<5 and isinstance(a, int):
         return [math.pi, math.e, 2**.5, (1+5**0.5)/2, float("inf")][a]
     
-    raise BadTypeCombinationError(".N", a)
+    raise BadTypeCombinationError(".n", a)
 
 # .p. seq
 def permutations(a):

--- a/macros.py
+++ b/macros.py
@@ -751,7 +751,7 @@ def Pformat(a, b):
 
 
 # .l. num, num
-def log(a, b):
+def log(a, b=math.e):
     if not is_num(a) or not is_num(b):
         raise BadTypeCombinationError(".l", a, b)
 
@@ -781,6 +781,12 @@ def maximal(a, b):
     maximum = max(map(a, seq))
     return list(filter(lambda elem: a(elem) == maximum, seq))
 
+# .n. mathematical constants
+def Pnumbers(a):
+    if a<5:
+        return [math.pi, math.e, 2**.5, (1+5**0.5)/2, float("inf")][a]
+    
+    raise BadTypeCombinationError(".N", a)
 
 # .p. seq
 def permutations(a):

--- a/web-docs.txt
+++ b/web-docs.txt
@@ -98,9 +98,10 @@ z 0 N z Variable. Autoinitializing to input.
 .F 2 N format a.format(b) - if b is a non-string sequence, it will be unpacked.
 .h 1 N hash
 .H 1 N hex Hexadecimal string representing _. Direct on int, interpreted as UTF-8 on str.
-.l 2 N log Python math.log(a, b).
+.l 2 N log Python math.log(a, b). Default for b is natural log.
 .m 2 N minimal Filter 2nd arg on elements which give minimal value when 1st arg is aplied. First arg is lambda, b ->
 .M 2 N maximal Filter 2nd arg on elements which give maximal value when 1st arg is aplied. First arg is lambda, Z ->
+.n 1 N Numbers List of mathematical constants: pi, e, sqrt(2), phi, infinity
 .N 1 Y the-one-after-M def :(N, T, Y): return _.
 .O 1 N oct Octal string representing _. Direct on int, interpreted as UTF-8 on str.
 .p 1 N permutations itertools.permutations(_).


### PR DESCRIPTION
We didn't have a bunch of numbers that seem necessary, including e and pi.

I added `.n` function which returns from a list of numbers: [pi, e, sqrt(2), phi, infinity]

I also made the default for log the same as python, natural log.


P.S. Completely unrelated, the seeding seems not to be working in the online interpreter. Is it fully updated?