### PR TITLE
Fixed slice not allowing None

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -221,7 +221,7 @@ def at_slice(a, b, c):
             return bool(re.search(b, a))
         else:
             return re.sub(b, c, a)
-    if isinstance(b, int) and isinstance(c, int):
+    if isinstance(b, int) and (isinstance(c, int) or c==None):
         return a[slice(b, c)]
 
     # There is no nice ABC for this check.


### PR DESCRIPTION
There was a bug in `at_slice` since it didn't allow `None` for the end point. Easy fix. We don't have a variable preinitialized to `None` but just doing `.xT` will return the value from seeding which is None.