### PR TITLE
Make run_length_encoding work for 1-element lists

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -861,7 +861,7 @@ def run_length_encoding(a):
                 rle.append([current_elem, running_count])
                 current_elem = elem
                 running_count = 1
-        rle.append([elem, running_count])
+        rle.append([current_elem, running_count])
         return rle
     if is_col(a):
         return run_length_encoding(sorted(a))


### PR DESCRIPTION
The original version of run_length_encoding failed on lists of length 1, with message 

    UnboundLocalError: local variable 'elem' referenced before assignment

This fixes that.