### PR TITLE
Fixed fold

### DIFF
--- a/data.py
+++ b/data.py
@@ -172,7 +172,7 @@ replacements = {
 
 syntax_sugar = {
     '=': (lambda c, r: r[:2] + c+r[1:], lambda n: n),
-    'F': (lambda c, r: ".U" + c + c_to_f['u'][0][14:18:3] + r[1:],
+    'F': (lambda c, r: ".U" + c + c_to_f['.U'][0][15:19:3] + r[1:],
           lambda n: n == 2)
 }
 


### PR DESCRIPTION
After the introduction of `reduce2`, we used that for the fold operator. However, this broke fold, because we forgot to update the name and the indicies for the variables in it. I fixed it.

P.S. This is really fragile, as we just saw. We need a better way, which i'll be working on, but here is the quick fix.