### PR TITLE
Fix for A (assign-pair)

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -91,11 +91,19 @@ environment['num_to_range'] = num_to_range
 
 
 # Function library. See data for letter -> function correspondences.
-# =. N/A, .=
+# =. N/A, .= A
 def assign(a, b):
-    if isinstance(a, str) and len(a) == 1:
-        environment[a] = copy.deepcopy(b)
-        return b
+    if isinstance(a, str):
+        if len(a) == 1:
+            environment[a] = copy.deepcopy(b)
+            return b
+        else:
+            var_names = a.strip('()').split(',')
+            if is_seq(b) and len(var_names) == len(b) == 2 and \
+                    all(len(var_name) == 1 for var_name in var_names):
+                for var_name, item in zip(var_names, b):
+                    environment[var_name] = copy.deepcopy(item)
+                return b
     raise BadTypeCombinationError("=", a, b)
 environment['assign'] = assign
 

--- a/test.py
+++ b/test.py
@@ -12,7 +12,7 @@ test_cases = [
     ('1  1', '1\n'),
     # Test !
     ('!0', 'True\n'),
-    ('!0.', 'True\n'),
+    ('!.0', 'True\n'),
     ('!"', 'True\n'),
     ('![', 'True\n'),
     ('!(', 'True\n'),
@@ -85,6 +85,12 @@ test_cases = [
     (':"abcde",0 3]"lol"', 'lolbclole\n'),
     (':"####$$$$"%2U8\\x', 'x#x#x$x$\n'),
     (':U10r4 7 8', '[0, 1, 2, 3, 8, 8, 8, 7, 8, 9]\n'),
+    # Test A
+    ('AGH,1 2', ''),
+    ('AGH,1 2GH', '1\n2\n'),
+    ('AGH,1 2HG', '2\n1\n'),
+    ('Abd"ab"bd', 'a\nb\n'),
+    ('ANNU2N', '1\n'),
     # Test X
     ('XUT5Z', '[0, 1, 2, 3, 4, 0, 6, 7, 8, 9]\n'),
     ('=YUT XY5Z', ''),


### PR DESCRIPTION
The new assign-method screwed up `A`, since `AGH,1 2` gets translated into `assign('(G,H)',(1,(2)))`. This code fixes the problem. 