### PR TITLE
Made I/O functions support urls

### DIFF
--- a/doc.txt
+++ b/doc.txt
@@ -27,7 +27,7 @@ Char, arity, begins line, mnemonic, details. When in doubt, similar to python.
 $  X N super-quote       Begins and ends Python literals. A Python literal is placed directly into the compiled Python output. Counts as one argument for arity purposes. Disabled online.
 %  2 N mod               On integers, modulus. On complex, mod real and imag separately. On string, string formatting. %<int><seq> is a modular slice, <seq>[::<int>] in Python.
 &  2 N and               Python's and-operator (short circuiting). &ab returns a, if it evaluates to a falsy value otherwise b.
-'  1 N quote-file        Cat file, return file a list of lines. File name as input.
+'  1 N quote-file        Cat file, return file a list of lines. File name as input. If starts with http, does get htttp request.
 (  I N tuple             Tuple constructor. Unbounded.
 )  X N close-paren       Ends functions, statements. Marks last line of statement, last arg. of function. Necessary for statements, unbounded functions.
 *  2 N times             Like python, multiplication, replication. Cartesian product on lists, tuples or sets.
@@ -149,6 +149,7 @@ z  0 N                   Variable. Autoinitializing to input.
 .t 2 N trigonometry      Collection of trigonometric functions. See below.
 .u 1 N unpack-close      Shorthand for .*_).
 .U 2 N reduce2           The 2 input reduce, uses first value of sequence as initial value and the rest as sequence. (b, Z) -> (k, Y) ->
+.w 2 N file write        Writes first arg to file second arg. If starts with http does http post request with data.
 .x 1 N group-x           product, over a non-str seq. Uses Pyth *. With num is random.seed.
 .z 0 N all-input         Take all of STDIN, return as list of lines. Cached. .Q and .z refer to the same data.
 .^ 3 N powmod            Python pow(a, b, c).

--- a/macros.py
+++ b/macros.py
@@ -12,6 +12,7 @@ import collections
 import numbers
 import binascii
 import hashlib
+import urllib.request
 from ast import literal_eval
 
 
@@ -218,7 +219,12 @@ environment['minus'] = minus
 # '. str.
 def read_file(a):
     if isinstance(a, str):
-        b = [lin[:-1] if lin[-1] == '\n' else lin for lin in (open(a))]
+        if a.startswith("http"):
+            b = urllib.request.urlopen(a)
+        else:
+            b = open(a)
+        
+        b = [lin[:-1] if lin[-1] == '\n' else lin for lin in b]
         return b
     raise BadTypeCombinationError("'", a)
 environment['read_file'] = read_file
@@ -1099,6 +1105,12 @@ environment['reduce2'] = reduce2
 def Pwrite(a, b="foo.txt"):
     if not isinstance(b, str):
         raise BadTypeCombinationError(".w", a, b)
+    
+    if b.startswith("http"):
+        if isinstance(a, dict):
+            a = "&".join("=".join(i) for i in a.items())
+        return [lin[:-1] if lin[-1] == '\n' else lin for lin in urllib.request.urlopen(b, a.encode("UTF-8"))]
+
     with open(b, 'a') as f:
         f.write(("\n".join(map(str, a)) if is_seq(a) and not isinstance(a, str)
                 else str(a))+"\n")

--- a/web-docs.txt
+++ b/web-docs.txt
@@ -6,7 +6,7 @@
 $ X N super-quote Begins and ends Python literals. A Python literal is placed directly into the compiled Python output. Counts as one argument for arity purposes. Disabled online.
 % 2 N mod On integers, modulus. On complex, mod real and imag separately. On string, string formatting. %<int><seq> is a modular slice, <seq>[::<int>] in Python.
 & 2 N Python's and-operator (short circuiting). &ab returns a, if it evaluates to a falsy value otherwise b.
-' 1 N quote-file Cat file, return file a list of lines. File name as input.
+' 1 N quote-file Cat file, return file a list of lines. File name as input. If starts with http, does get htttp request.
 ( I N tuple Tuple constructor. Unbounded.
 ) X N close-paren Ends functions, statements. Marks last line of statement, last arg. of function. Necessary for statements, unbounded functions.
 * 2 N times Like python, multiplication, replication. Cartesian product on lists, tuples or sets.
@@ -117,6 +117,7 @@ z 0 N z Variable. Autoinitializing to input.
 .t 2 N trigonometry Collection of trigonometric functions.
 .U 2 N reduce2           The 2 input reduce, uses first value of sequence as initial value and the rest as sequence. (b, Z) -> (k, Y) ->
 .u 1 N unpack-close Shorthand for .*_).
+.w 2 N file-write. Writes first arg to file second arg. If starts with http does http post request with data.
 .x 1 N multiply product, over a non-str seq. Uses Pyth *. With num is random.seed.
 .z 0 N all-input Take all of stdin, return as list of lines. Cached. .Q and .z refer to the same data.
 .^ 3 N powmod Python pow(a, b, c).


### PR DESCRIPTION
Just a nice feature to have for the I/O functions `'` and `.w`. Now if the filename starts with `http` its interpreted as a url and `urllib.request.urlopen` is used. Read does get request, write uses write data as post data, joining if dict into needed form. Both return parsed in same way as read as list of lines.