### PR TITLE
Added Operator Chaining

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -137,7 +137,7 @@ class OpChain(object):
     def __bool__(self):
         return bool(eval(self.chain))
     
-    def __str__(self):
+    def __repr__(self):
         return str(bool(self))
 
 # If argument is a number, turn it into a range.
@@ -528,11 +528,15 @@ def gte(a, b):
         return a.issuperset(b)
     if is_seq(a) and is_num(b):
         return a[b-1:]
-    if is_num(a) and is_num(b) or\
-            isinstance(a, list) and isinstance(b, list) or\
-            isinstance(a, tuple) and isinstance(b, tuple) or\
-            isinstance(a, str) and isinstance(b, str):
-        return a >= b
+    if (is_num(a) or isinstance(a, OpChain)) and is_num(b) or\
+            isinstance(a, (list, OpChain)) and isinstance(b, list) or\
+            isinstance(a, (tuple, OpChain)) and isinstance(b, tuple) or\
+            isinstance(a, (str, OpChain)) and isinstance(b, str):
+        
+        if isinstance(a, OpChain):
+            a.chain+=">="+str(b)
+            return a
+        return OpChain(str(a)+">="+str(b))
     raise BadTypeCombinationError("g", a, b)
 environment['gte'] = gte
 environment['H'] = {}

--- a/macros.py
+++ b/macros.py
@@ -129,6 +129,16 @@ class memoized(object):
             return value
 environment['memoized'] = memoized
 
+#Custom class for operator chaining
+class OpChain(object):
+    def __init__(self, initial_chain):
+        self.chain=initial_chain
+    
+    def __bool__(self):
+        return bool(eval(self.chain))
+    
+    def __str__(self):
+        return str(bool(self))
 
 # If argument is a number, turn it into a range.
 def num_to_range(arg):
@@ -385,11 +395,15 @@ def lt(a, b):
         return a[:b]
     if isinstance(a, complex) or isinstance(b, complex):
         return abs(a) < abs(b)
-    if is_num(a) and is_num(b) or\
-            isinstance(a, list) and isinstance(b, list) or\
-            isinstance(a, tuple) and isinstance(b, tuple) or\
-            isinstance(a, str) and isinstance(b, str):
-        return a < b
+    if (is_num(a) or isinstance(a, OpChain)) and is_num(b) or\
+            isinstance(a, (list, OpChain)) and isinstance(b, list) or\
+            isinstance(a, (tuple, OpChain)) and isinstance(b, tuple) or\
+            isinstance(a, (str, OpChain)) and isinstance(b, str):
+        
+        if isinstance(a, OpChain):
+            a.chain+="<"+str(b)
+            return a
+        return OpChain(str(a)+"<"+str(b))
     raise BadTypeCombinationError("<", a, b)
 environment['lt'] = lt
 
@@ -402,11 +416,15 @@ def gt(a, b):
         return a[b:]
     if isinstance(a, complex) or isinstance(b, complex):
         return abs(a) > abs(b)
-    if is_num(a) and is_num(b) or\
-            isinstance(a, list) and isinstance(b, list) or\
-            isinstance(a, tuple) and isinstance(b, tuple) or\
-            isinstance(a, str) and isinstance(b, str):
-        return a > b
+    if (is_num(a) or isinstance(a, OpChain)) and is_num(b) or\
+            isinstance(a, (list, OpChain)) and isinstance(b, list) or\
+            isinstance(a, (tuple, OpChain)) and isinstance(b, tuple) or\
+            isinstance(a, (str, OpChain)) and isinstance(b, str):
+        
+        if isinstance(a, OpChain):
+            a.chain+=">"+str(b)
+            return a
+        return OpChain(str(a)+">"+str(b))
     raise BadTypeCombinationError(">", a, b)
 environment['gt'] = gt
 
@@ -605,7 +623,12 @@ environment['N'] = '"'
 
 # n. All.
 def ne(a, b):
-    return a != b
+    if isinstance(a, OpChain):
+        a.chain+="!="+str(b)
+        return a
+
+    else:
+        return OpChain(str(a)+"!="+str(b))
 environment['ne'] = ne
 
 
@@ -670,7 +693,13 @@ environment['Pprint'] = Pprint
 
 # q. All.
 def equal(a, b):
-    return a == b
+    if isinstance(a, OpChain):
+        a.chain+="=="+str(b)
+        return a
+
+    else:
+        return OpChain(str(a)+"=="+str(b))
+    
 environment['equal'] = equal
 
 


### PR DESCRIPTION
One of the best features of Python is [operator chaining](https://docs.python.org/2/reference/expressions.html#not-in). This was obviously missing in Pyth since we evaluate each operator individually. This is my attempt to fix this. Instead of the operator comparisons returning a Boolean, I instead made them return a custom `OpChain` object which contains the chain to expand as a string. When it needs to be used as a boolean, the overloaded `__bool__` method evaluates the chain. The `__str__` method also returns `"True"` or `"False"`, making it virtually indistinguishable from a boolean.

There is probably a bug with this somewhere, so tell me if you catch one. I have written this for `==`, `!=`, `<`, and `>` so far.