### PR TITLE
Added image I/O

### DIFF
--- a/doc.txt
+++ b/doc.txt
@@ -27,7 +27,7 @@ Char, arity, begins line, mnemonic, details. When in doubt, similar to python.
 $  X N super-quote       Begins and ends Python literals. A Python literal is placed directly into the compiled Python output. Counts as one argument for arity purposes. Disabled online.
 %  2 N mod               On integers, modulus. On complex, mod real and imag separately. On string, string formatting. %<int><seq> is a modular slice, <seq>[::<int>] in Python.
 &  2 N and               Python's and-operator (short circuiting). &ab returns a, if it evaluates to a falsy value otherwise b.
-'  1 N quote-file        Cat file, return file a list of lines. File name as input. If starts with http, does get http request.
+'  1 N quote-file        Cat file, return file a list of lines. File name as input. If starts with http, does get http request. If image file returns bitmap nested array of tuples (grayscale single value instead of tuples).
 (  I N tuple             Tuple constructor. Unbounded.
 )  X N close-paren       Ends functions, statements. Marks last line of statement, last arg. of function. Necessary for statements, unbounded functions.
 *  2 N times             Like python, multiplication, replication. Cartesian product on lists, tuples or sets.
@@ -162,7 +162,7 @@ z  0 N                   Variable. Autoinitializing to input.
 .U 2 N reduce2           The 2 input reduce, uses first value of sequence as initial value and the rest as sequence. (b, Z) -> (k, Y) ->
 .V 2 Y forever           An infinite for loop. b iterates over an infinite sequence starting at the input, same sequence as .f.
                          On num, incrementing sequence. On str, rupy's .succ sequence.
-.w 2 N file write        Writes first arg to file second arg. If starts with http does http post request with data.
+.w 2 N file write        Writes first arg to file second arg. If starts with http does http post request with data. If array, writes to image file as bitmap. Default file name is o.txt/png.
 .x 2 N try-except        Attempts to run first arg. If an exception occurs, runs the second.
 .z 0 N all-input         Take all of STDIN, return as list of lines. Cached. .Q and .z refer to the same data.
 .^ 3 N powmod            Python pow(a, b, c).

--- a/macros.py
+++ b/macros.py
@@ -15,6 +15,7 @@ import string
 import sys
 import urllib.request
 from ast import literal_eval
+from PIL import Image
 
 
 # Type checking
@@ -287,6 +288,21 @@ environment['minus'] = minus
 # '. str.
 def read_file(a):
     if isinstance(a, str):
+        if any(a.lower().endswith("." + i) for i in ["png", "jpg", "jpeg", "gif", "svg", "ppm", "pgm", "pbm"]):
+            img = Image.open(a)
+            data = list(img.getdata())
+            
+            #If alpha all 255, take out alpha
+            if len(data[0])>3 and all(i[3]==255 for i in data):
+                data = [i[:3] for i in data]
+            
+            #Check grayscale
+            if all(i.count(i[0])==len(i) for i in data):
+                data = [i[0] for i in data]
+            
+            data = chop(data, img.size[0])
+            return data
+            
         if a.startswith("http"):
             b = urllib.request.urlopen(a)
         else:
@@ -294,6 +310,8 @@ def read_file(a):
 
         b = [lin[:-1] if lin[-1] == '\n' else lin for lin in b]
         return b
+        
+
     raise BadTypeCombinationError("'", a)
 environment['read_file'] = read_file
 
@@ -1414,7 +1432,7 @@ environment['reduce2'] = reduce2
 
 
 # .w. write
-def Pwrite(a, b="foo.txt"):
+def Pwrite(a, b=''):
     if not isinstance(b, str):
         raise BadTypeCombinationError(".w", a, b)
 
@@ -1424,9 +1442,25 @@ def Pwrite(a, b="foo.txt"):
         return [lin[:-1] if lin[-1] == '\n' else lin for lin
                 in urllib.request.urlopen(b, a.encode("UTF-8"))]
 
-    with open(b, 'a') as f:
-        f.write(("\n".join(map(str, a)) if is_seq(a) and not isinstance(a, str)
-                else str(a))+"\n")
+    prefix = b.split('.')[0] if b else 'o'
+    suffix = b.split('.')[1] if '.' in b else None
+
+    if is_lst(a):
+        suffix = suffix if suffix else 'png'
+        
+        if not is_lst(a[0][0]):
+            a = [(i, i, i) for i in a]
+        
+        img =  Image.new("RGB" + ("A" if len(a[0][0])>3 else ""), (len(a[0]), len(a)))
+        img.putdata(Psum(a))
+        img.save(prefix + "." + suffix)
+    else:
+        suffix = suffix if suffix else ".txt"
+
+        with open(prefix + '.' + suffix, 'a') as f:
+            f.write(("\n".join(map(str, a)) if is_seq(a) and not isinstance(a, str)
+            else str(a))+"\n")
+
 environment['Pwrite'] = Pwrite
 
 

--- a/web-docs.txt
+++ b/web-docs.txt
@@ -6,7 +6,7 @@
 $ X N super-quote Begins and ends Python literals. A Python literal is placed directly into the compiled Python output. Counts as one argument for arity purposes. Disabled online.
 % 2 N mod On integers, modulus. On complex, mod real and imag separately. On string, string formatting. %<int><seq> is a modular slice, <seq>[::<int>] in Python.
 & 2 N Python's and-operator (short circuiting). &ab returns a, if it evaluates to a falsy value otherwise b.
-' 1 N quote-file Cat file, return file a list of lines. File name as input. If starts with http, does get htttp request.
+' 1 N quote-file Cat file, return file a list of lines. File name as input. If starts with http, does get http request. If image file returns bitmap nested array of tuples (grayscale single value instead of tuples).
 ( I N tuple Tuple constructor. Unbounded.
 ) X N close-paren Ends functions, statements. Marks last line of statement, last arg. of function. Necessary for statements, unbounded functions.
 * 2 N times Like python, multiplication, replication. Cartesian product on lists, tuples or sets.
@@ -122,7 +122,7 @@ z 0 N z Variable. Autoinitializing to input.
 .u 3 N cumul-reduce Just like u, except returns a collection of all intermediate states. lambda N, Y.
 .U 2 N reduce2 The 2 input reduce, uses first value of sequence as initial value and the rest as sequence. (b, Z) -> (k, Y) ->
 .V S Y forever An infinite for loop. b iterates over an infinite sequence starting at the input, same sequence as .f. On num, incrementing sequence. On str, rupy's .succ sequence.
-.w 2 N file-write. Writes first arg to file second arg. If starts with http does http post request with data.
+.w 2 N file-write Writes first arg to file second arg. If starts with http does http post request with data. If array, writes to image file as bitmap. Default file name is o.txt/png.
 .x 2 N try-except Attempts to run first arg. If an exception occurs, runs the second.
 .z 0 N all-input Take all of stdin, return as list of lines. Cached. .Q and .z refer to the same data.
 .^ 3 N powmod Python pow(a, b, c).


### PR DESCRIPTION
A huge roadblock to pyth participating in many challenges was image i/o. In many cases it was impossible, and even when `ppm` was allowed, headers and formatting kills your score when both parsing and generating. So I added native image support to `'` and `.w` with PIL.

`'` detects image file names and makes a nested array. It removes alpha when all 255 and condenses grayscale tuples into a single value.

`.w` detects arrays and does the reverse in regards to alpha and grayscale. I also changed the default filename behavior in `.w`. It now first creates a filename-prefix, defaulting to `"o"` which you can override by passing in like `"foo"`and then a suffix which defaults to `.png` and `.txt`. You cant override just suffix, but you both as expected like `"foo.jpg"`.

A possible improvement that might be disruptive is on `.w` to take grayscale images with only `0` and `1` as values and assume B&W and make the `1`'s `255`'s, and the opposite on `'`.