### PR TITLE
Fixed excercises to reflect latest version.

### DIFF
--- a/docs/simple-programs.rst
+++ b/docs/simple-programs.rst
@@ -270,7 +270,7 @@ Note: All functions are automatically `memoized <http://en.wikipedia.org/wiki/Me
 The recursive factorial is a common solution. It works by taking the factorial of the number lower than it, recursively, until you get to zero, which returns 1. Let's first define our factorial function's base case of zero::
 
     ==================== 5 chars =====================
-    L?Tb1
+    L?bT1
     ==================================================
     @memoized
     def subsets(b):
@@ -279,16 +279,16 @@ The recursive factorial is a common solution. It works by taking the factorial o
 
 Here I'm using ``T`` as a placeholder for the recursive case.
 
-Also, notice that the ternary operator ``?abc`` evaluates to ``a if b else c``.
+Also, notice that the ternary operator ``?abc`` evaluates to ``if a then b else c``.
 
 Now let's complete the factorial function::
 
     ==================== 9 chars =====================
-    L?*bytbb1
+    L?b*bytb1
     ==================================================
     @memoized
     def subsets(b):
-     return times(b,(subsets(tail(b)) if b else 1))
+     return (times(b,subsets(tail(b))) if b else 1)
     ==================================================
 
 This uses ``t``, the decrement function, to recursively call the function on the input minus 1.
@@ -298,21 +298,22 @@ Pretty simple. Now we have to take input and run the function::
     input: 5
 
     ==================== 11 chars ====================
-    L?*bytbb1yQ
+    L?b*bytb1yQ
     ==================================================
-    Q=copy(eval(input()))
-    @memoized
-    def subsets(b):
-     return (times(b,subsets(tail(b))) if b else 1)
-    Pprint("\n",subsets(Q))
+	assign('Q',literal_eval(input()))
+	@memoized
+	def subsets(b):
+	 return (times(b,subsets(tail(b))) if b else 1)
+	imp_print(subsets(Q))
     ==================================================
+    120
 
 Another factorial example...
 
 3.1.6. Factorials With Reduce
 -----------------------------
 
-The best way to do it, the way most people would do it, would be to use the reduce function. The ``u`` operator works exactly like Python's reduce, except for an implicit lambda so you can just write code without a lambda deceleration. All a factorial is a reduction by the product operator on the range from 1 through n. This makes it very easy. The reduce function takes a statement of code, the sequence to iterate on, and a base case::
+The best way to do it, the way most people would do it, would be to use the reduce function. The ``u`` operator works exactly like Python's reduce, except for an implicit lambda so you can just write code without a lambda declaration. All a factorial is, is a reduction by the product operator on the range from 1 through n. This makes it very easy. The reduce function takes a statement of code, the sequence to iterate on, and a base case::
 
 	input: 5
 	
@@ -363,13 +364,13 @@ The `Fibonacci sequence <http://en.wikipedia.org/wiki/Fibonacci_number>`_ is ano
     ==================== 15 chars ====================
     J1VQJKZ=ZJ=J+ZK
     ==================================================
-    Q=copy(eval(input()))
-    J=copy(1)
-    for N in urange(Q):
-    Pprint("\n",J)
-    K=Z
-    Z=copy(J)
-    J=copy(plus(Z,K))
+	assign('Q',literal_eval(input()))
+	assign("J",1)
+	for N in num_to_range(Q):
+	 imp_print(J)
+	 assign("K",Z)
+	 assign('Z',J)
+	 assign('J',plus(Z,K))
     ==================================================
     1
     1
@@ -384,18 +385,18 @@ The `Fibonacci sequence <http://en.wikipedia.org/wiki/Fibonacci_number>`_ is ano
 
 Notice that we used ``Z`` as one of the variables. ``Z`` is preinitialized to ``0``, which was appropriate to use here. All of Pyth's variables have some sort of special property.
 
-That was pretty easy, but this can be shortened with the double-assignment operator, ``A``. This has an arity of 3 and takes two variable names, and then a tuple of two values. We use the ``,`` two element tuple creation operator to make the tuple::
+That was pretty easy, but this can be shortened (or should be) with the double-assignment operator, ``A``. This has an arity of 1 and takes a tuple of two values. This shortens the assignment, but in this case we have to re-assign ``H`` and ``G`` since A implicitly uses them and their defaults are ``{}`` and an alphabetical string respectively. We use the ``(`` tuple creation operator to make the tuple::
 
     input: 10
 
-    ==================== 13 chars ====================
-    J1VQJAZJ,J+ZJ
+    ==================== 14 chars ====================
+    A(Z1)VQHA(H+HG
     ==================================================
-    Q=copy(eval(input()))
-    J=copy(1)
-    for N in urange(Q):
-     Pprint("\n",J)
-     (Z,J)=copy((J,plus(Z,J)))
+	assign('Q',literal_eval(input()))
+	assign('[G,H]',Ptuple(Z,1))
+	for N in num_to_range(Q):
+	 imp_print(H)
+	 assign('[G,H]',Ptuple(H,plus(H,G)))
     ==================================================
     1
     1


### PR DESCRIPTION
The way `?`, `A` and `.x` work has changed and this causes the examples to not function properly. I've corrected them, except the one that uses `.x` because I don't know how.