### PR TITLE
Added test suite feature to interpreter

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
                             Lines / Test: 
                             <input type="number" class="form-control" id="input-size" style="display: inline;width: 70px;" value="{{ input_size }}" min="1">
                         </div>
-                        <a id="switcher" class="bottom-row" href="javascript: input_type = input_type ? 0 : 1; change_input_type()">Test Suite -></a>
+                        <a id="switcher" class="bottom-row" href="javascript: input_type = input_type ? 0 : 1; change_input_type()">Switch to Test Suite</a>
                     </div>
                     
                     
@@ -144,7 +144,7 @@
                 $("#input").css("display", input_type ? "none" : "block")
                 $("#test-suite").css("display", input_type ? "block" : "none")
                 $("#input-size-cont").css("display", input_type ? "block" : "none")
-                $('#switcher').text(input_type ? "Regular Input ->" : "Test Suite ->")
+                $('#switcher').text(input_type ? "Switch to Regular Input" : "Switch to Test Suite")
             }
             
 			function permalink() {

--- a/index.html
+++ b/index.html
@@ -59,9 +59,21 @@
 				max-height: 200px;
 				overflow: auto;
 			}
-			#code, #input, #output {
+			#code, #input, #output, #test-suite-input {
 				font-family: monospace;
 			}
+            
+            #test-suite {
+                display: none;
+            }
+            
+            #switcher {
+                color: gray;
+            }
+            
+            #middle-row {
+                padding-bottom: 10px;
+            }
 		</style>
 	</head>
 	<body>
@@ -76,7 +88,23 @@
 					</div>
 					<button id="run-button" class="btn btn-primary">Run Program! (Ctrl-Enter)</button>
 					<textarea id="code" placeholder="Code" class="form-control" rows="7">{{ code }}</textarea>
-					<textarea id="input" placeholder="Input" class="form-control" rows="7">{{ input }}</textarea>
+                    
+                    <div id="middle-row">
+                        <div id="input-size-cont" style="display: none;">
+                            Lines / Test: 
+                            <input type="number" class="form-control" id="input-size" style="display: inline;width: 70px;" value="{{ input_size }}" min="1">
+                        </div>
+                        <a id="switcher" class="bottom-row" href="javascript: input_type = input_type ? 0 : 1; change_input_type()">Test Suite -></a>
+                    </div>
+                    
+                    
+                    <div id="inputs">
+				        <textarea id="input" placeholder="Input" class="form-control" rows="7">{{ input }}</textarea>
+                        <div id="test-suite">
+                            <textarea id="test-suite-input" placeholder="Test Cases" class="form-control" rows="7">{{ test_suite_input }}</textarea>
+                        </div>
+                    </div>
+                    
 					<br>
 					<div class='bottom-row'>
 						Debug on?: <input id="debug" type="checkbox" {% if debug %} checked {% endif %}>
@@ -110,27 +138,45 @@
 			</div>
 		</div>
 		<script>
+            input_type = {{ test_suite }}
+            
+            function change_input_type() {
+                $("#input").css("display", input_type ? "none" : "block")
+                $("#test-suite").css("display", input_type ? "block" : "none")
+                $("#input-size-cont").css("display", input_type ? "block" : "none")
+                $('#switcher').text(input_type ? "Regular Input ->" : "Test Suite ->")
+            }
+            
 			function permalink() {
 				params={code: $('#code').val()}
 				if ($('#input').val()) params.input=$('#input').val()
+                if (input_type) params.test_suite = input_type
+                if ($('#test-suite-input').val()) params.test_suite_input=$('#test-suite-input').val()
 				if (!$('#debug').is(':checked')) params.debug=0
 				if ($('#debug').is(':checked')) params.debug=1
+                if ($("#input-size").val()!=1) params.input_size=$("#input-size").val()
 				document.location="?"+$.param(params)
 			}
 
 			function submit_code() {
-				$.post('/submit', {
-					code: $('#code').val(),
-					input: $('#input').val(),
-					debug: $('#debug').is(':checked')? 1 : 0
-					},
-					function(data) {
-						$('#output').text(data);
-						$('#output-container').show()
-				});
+                console.log(input_type)
+                $.post(input_type ? '/submit_test_suite' : '/submit', {
+                    code: $('#code').val(),
+                    input: input_type ? $('#test-suite-input').val() : $('#input').val(),
+                    debug: $('#debug').is(':checked')? 1 : 0,
+                    input_size: $('#input-size').val()
+                    },
+                    function(data) {
+                        $('#output').text(data);
+                        $('#output-container').show()
+                });
+                
 			}
+                
 			$(function() {
 				$('#run-button').click(submit_code);
+                
+                change_input_type()
 
 				$('#code').keyup(function(e) {
 					$('#length').text(e.target.value.length);
@@ -210,16 +256,18 @@
 				}
 
 				window.addEventListener('resize', onresize);
-				$('#code').keydown(function (e) {
+                
+                ctrl_enter_handler = function (e) {
    				     if (e.ctrlKey && (e.keyCode==10 || e.keyCode == 13)) {
                                         submit_code(); 
 				     }
-				});
-				$('#input').keydown(function (e) {
-   				     if (e.ctrlKey && (e.keyCode==10 || e.keyCode == 13)) {
-                                        submit_code(); 
-				     }
-				});
+				}
+                
+				$('#code').keydown(ctrl_enter_handler);
+				$('#input').keydown(ctrl_enter_handler);
+				$('#test-suite-input').keydown(ctrl_enter_handler);
+				$('#input-size').keydown(ctrl_enter_handler);
+                
 				onresize();
 				$('#code').focus()
 			});

--- a/server.py
+++ b/server.py
@@ -60,7 +60,7 @@ def submit_test_suite():
 	debug_on = int(request.form.get('debug'), 0)
 	
 	return Response("\n".join([run_code(code_message, inputs[0], debug_on)] + \
-				[run_code(code_message, i, False) for i in inputs[1:]]))
+				[run_code(code_message, i, False) for i in inputs[1:]]) if inputs else "")
 
 @app.route('/<path>')
 def other(path):

--- a/server.py
+++ b/server.py
@@ -16,18 +16,15 @@ def root():
                            formatted_time=formatted_time,
                            code=request.args.get('code', ''),
                            input=request.args.get('input', ''),
-                           debug=int(request.args.get('debug', 0)))
+                           debug=int(request.args.get('debug', 0)),
+                           test_suite=int(request.args.get('test_suite', 0)),
+                           test_suite_input=request.args.get('test_suite_input', ''),
+                           input_size=int(request.args.get('input_size', 1)))
 
-
-@app.route('/submit', methods=['POST'])
-def submit():
+def run_code(code_message, input_message, debug_on):
     resp = ''
-
-    code_message = request.form.get('code', '')
-    input_message = request.form.get('input', '')
+    
     input_message += '\n'
-    debug_on = int(request.form.get('debug'), 0)
-
     pyth_code = '\n'.join(code_message.split("\r\n"))
     pyth_process = \
         subprocess.Popen(['/usr/bin/env',
@@ -44,9 +41,26 @@ def submit():
 
     if code_message:
         resp += output.decode() + (errors if errors else '')
+    
+    return resp
 
-    return Response(resp)
+@app.route('/submit', methods=['POST'])
+def submit():
+    code_message = request.form.get('code', '')
+    input_message = request.form.get('input', '')
+    debug_on = int(request.form.get('debug'), 0)
 
+    return Response(run_code(code_message, input_message, debug_on))
+
+@app.route('/submit_test_suite', methods=['POST'])
+def submit_test_suite():
+	code_message = request.form.get('code', '')
+	input_size = int(request.form.get('input_size', '1'), 0)
+	inputs = ["\n".join(i) for i in zip(*[iter(request.form.get('input', '').split("\n"))]*input_size)]
+	debug_on = int(request.form.get('debug'), 0)
+	
+	return Response("\n".join([run_code(code_message, inputs[0], debug_on)] + \
+				[run_code(code_message, i, False) for i in inputs[1:]]))
 
 @app.route('/<path>')
 def other(path):


### PR DESCRIPTION
Adding scaffolding to existing code to make test suites is annoying, messes up byte counts, and does not work with multi-line inputs. So I added that to the online interpreter.

Above the normal input textbox, there is a gray link which says "Test Suite ->":

![image](https://cloud.githubusercontent.com/assets/10355450/9033312/0155dd76-3994-11e5-8603-1e04dddb53a6.png)

Then when you click on that, it changes the textbox to another one and adds numeric input for input size:

![image](https://cloud.githubusercontent.com/assets/10355450/9033338/2cd19918-3994-11e5-8706-64bab45a4864.png)

When you run it, it runs all of them, and then returns their outputs, separated by linebreaks. The debug parameter is only honored on the first test, the rest all have no debug:

![image](https://cloud.githubusercontent.com/assets/10355450/9033377/72d10304-3994-11e5-903f-f3b59bb31318.png)


The permalinks all also work pretty naturally. Both textboxes are preserved over permalinks, though obviously, it also preserves which one was the current one.

Internally, I have encapsulated the code running in a function, and made two separate handlers for regular submissions and test suites.

I have hosted a live copy on my Koding VM here: http://maltysen.koding.io/ to play around on for bugs & suggestions before deciding on the pull request. I have not done animations for the boxes, but if you think its necessary, I can add it.