### PR TITLE
Convert items to string before joining

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -146,7 +146,7 @@ environment['num_to_range'] = num_to_range
 # Implicit print
 def imp_print(a):
     if is_lst(a):
-        print('\n'.join(a))
+        print('\n'.join(map(str, a)))
     elif a is not None:
         print(a)
 environment['imp_print'] = imp_print


### PR DESCRIPTION
Lots of tests failed because of the `join` only joins strings. E.g. the test `U3` broke, because all sequence items are numbers. 

Easy fix with `map(str, a)`. All tests passes now.  