### PR TITLE
Fix documentation of .[

### DIFF
--- a/rev-doc.txt
+++ b/rev-doc.txt
@@ -297,12 +297,12 @@ z                         Variable. Autoinitialized to input().
 .U <l:bZ> <seq>           Reduce with no starting value. Reduce from left to right, with initial value B[0]. A(_, _) takes inputs current value, next element of B. b, Z -> k, Y ->.
 .W <l:H> <l:Z> <any>      Functional while. While A(value) is truthy, value = B(value). value starts as C. return ending value.
 .Z <str>                  Attempt to decompress A using zlip.decompress. If that fails, compress it with zlib.compress(A, 9).
-.[ <str> <str> <int>      Pad A on the left with a prefix of repeated copies of B to a length of the nearest multiple of C.
-.[ <str> <int> <str>      Pad C on the right with a prefix of repeated copies of A to a length of the nearest multiple of B.
+.[ <str> <str> <int>      Pad A on the right with a prefix of repeated copies of B to a length of the nearest multiple of C.
+.[ <str> <int> <str>      Pad C on the left with a prefix of repeated copies of A to a length of the nearest multiple of B.
 .[ <int> <str> <str>      Pad B on evenly on both sides with a prefix of repeated copies of C to a length of the nearest multiple of A. Ties broken to the right.
-.[ <seq> <any> <int>      Pad list(A) on the left with copies of B as elements to a length of the nearest multiple of C.
+.[ <seq> <any> <int>      Pad list(A) on the right with copies of B as elements to a length of the nearest multiple of C.
 .[ <any> <int> <seq>      Pad list(C) on the left with copies of A as elements to a length of the nearest multiple of B.
-.[ <int> <seq> <any>      Pad list(B) on both sides with copies of B as elements to a length of the nearest multiple of C. Ties broken to the right.
+.[ <int> <seq> <any>      Pad list(B) on both sides with copies of C as elements to a length of the nearest multiple of A. Ties broken to the right.
 ._ <seq>                  All prefixes of A, length 1 to len(A).
 ._ <num>                  Sign of A. 1 if A > 0, -1 if A < 0, 0 otherwise.
 .a <num>                  Absolute value. abs in Python.


### PR DESCRIPTION
The docs for `.[` (pad) don't match the implementation.

The implementation is rather messy, but I read through it carefully, and this change should reflect the actual code.