### PR TITLE
Made .d sleep more useful

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -1235,7 +1235,7 @@ def dict_or_date(a):
             if a == 9:
                 return today.weekday()
     if is_num(a):
-        time.sleep(a / 10)
+        time.sleep(-a)
         return
     if is_col(a):
         return dict(a)

--- a/macros.py
+++ b/macros.py
@@ -1235,7 +1235,7 @@ def dict_or_date(a):
             if a == 9:
                 return today.weekday()
     if is_num(a):
-        time.sleep(a)
+        time.sleep(a / 10)
         return
     if is_col(a):
         return dict(a)

--- a/macros.py
+++ b/macros.py
@@ -1235,7 +1235,7 @@ def dict_or_date(a):
             if a == 9:
                 return today.weekday()
     if is_num(a):
-        time.sleep(-a)
+        time.sleep(abs(a))
         return
     if is_col(a):
         return dict(a)


### PR DESCRIPTION
`.d` for time < 10 secs cannot be done since it will be interpreted as the other keys. This lets you sleep for small periods of time by dividing the time given by 10. I initially had the idea of simply doing miliseconds as input, but this seemed like a better idea.