### PR TITLE
Added REPL mode

### DIFF
--- a/pyth.py
+++ b/pyth.py
@@ -641,6 +641,9 @@ Use "help [token]" to get information about that token, or read rev-doc.txt""")
     def postloop(self):
         print()
 
+    def complete(self):
+        pass
+
 if __name__ == '__main__':
     global safe_mode, c_to_f
 
@@ -652,9 +655,7 @@ if __name__ == '__main__':
             or "--repl" in sys.argv[1:] \
             or len(sys.argv) == 1:
 
-        #setting to None not working, so temp fix setting to key doesn't exist
-        #wating for answer on http://stackoverflow.com/questions/37981271
-        Repl("skjlksdjfjdsf").cmdloop()
+        Repl().cmdloop()
 
     elif len(sys.argv) > 1 and \
             "-h" in sys.argv[1:] \

--- a/pyth.py
+++ b/pyth.py
@@ -22,6 +22,7 @@ import copy as c
 import sys
 import io
 import cmd
+import traceback
 
 sys.setrecursionlimit(100000)
 
@@ -617,7 +618,25 @@ each one will be passed into the next one's input stream.
 """
 
     def default(self, code):
-        self.output, error = run_code(code, self.output)
+        global preps_used
+
+        old_stdout, old_stdin = sys.stdout, sys.stdin
+
+        sys.stdout = io.StringIO()
+        sys.stdin = io.StringIO(self.output)
+
+        preps_used = set()
+        x=general_parse(code)
+        try:
+            exec(x, environment)
+        except Exception as e:
+            traceback.print_exc()
+
+        self.output = sys.stdout.getvalue()
+
+        sys.stdout = old_stdout
+        sys.stdin = old_stdin
+
         print(self.output, end="")
 
     def do_EOF(self, line):


### PR DESCRIPTION
I found myself using Pyth for a lot of daily "desktop calculator" tasks, so I wrote a little REPL for it. This is called up when one has no cmd args, or uses the `-r` or `--repl` flags.

It just runs each line as a program, but sends the output of one into the other allowing things like: 

```
>>> 6
6
>>> y
12
>>> 
24
>>> +3
27
>>> U
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]
```

(Note that an empty line repeats the previous command).

It also uses the [`cmd`](https://docs.python.org/3/library/cmd.html) module for up-arrow/down-arrow history functionality.

I also included `help` functionality that lookups the command you enter in the docs:

```
>>> help h
h  <num>                  A + 1.
>>> ? m
m  <l:d> <col/num>        Map A(_) over B. d -> k -> b ->
```

(`help` and `?` are the same).

I made up the intro txt, flag name, etc. you probably want to change them, and there probably are some bugs.