### PR TITLE
Huge asymptotic speedup for base conversion

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -708,11 +708,15 @@ def to_base_ten(arb, base):
     # Special cases
     if abs(base) == 1:
         return len(arb)
-    acc = 0
-    for digit in arb:
-        acc *= base
-        acc += digit
-    return acc
+    if len(arb) < 2:
+        return arb[0] if arb else 0
+    digits = []
+    it = iter(arb)
+    if len(arb) % 2 != 0:
+        digits.append(next(it))
+    for digit in it:
+        digits.append(digit * base + next(it))
+    return to_base_ten(digits, base * base)
 
 
 # j. str.
@@ -737,8 +741,19 @@ def from_base_ten(arb, base):
         return [0] * arb
     # Main routine
     base_list = []
-    work = arb
-    while work != 0:
+    it = reversed(from_base_ten(arb, base * base) if abs(arb) >= abs(base) else [arb])
+    digit = next(it)
+    clock = 0
+    work = 0
+    while clock >= 0 or work != 0:
+        if clock == 0:
+            work += digit
+            try:
+                digit = next(it)
+                clock = 2
+            except StopIteration:
+                digit = 0
+        clock -= 1
         work, remainder = divmod(work, base)
         if remainder < 0:
             work += 1


### PR DESCRIPTION
Use a recursive algorithm based on repeatedly squaring the base for both `to_base_ten` and `from_base_ten`.  The `from_base_ten` speedup is not as huge as I hoped, because Python’s divmod is [pathetically slow](https://bugs.python.org/issue3451), but it at least it’s slow C code rather than slow Python code.

Here are some benchmarks:

```
Old to_base_ten:
  lC*d    100000    2.6s
  lC*d    200000   10s
  lC*d    400000   42s

New to_base_ten:
  lC*d    100000    0.046s
  lC*d    200000    0.093s
  lC*d    400000    0.19s
  ⋮
  lC*d  12800000    7.5s
  lC*d  25600000   16s
  lC*d  51200000   39s

Old from_base_ten:
  lC^256   50000    4.9s
  lC^256  100000   19s
  lC^256  200000   76s

New from_base_ten:
  lC^256   50000    0.12s
  lC^256  100000    0.37s
  lC^256  200000    1.3s
  lC^256  400000    4.8s
  lC^256  800000   19s
  lC^256 1600000   76s
```
