### PR TITLE
Fix binomial coefficient computation (.C A B) for A < B ≤ 2·A

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -1259,11 +1259,13 @@ environment['Pbin'] = Pbin
 def combinations(a, b):
     if isinstance(a, int) and isinstance(b, int):
         # compute n C r
-        n, r = a, min(b, b - a)
+        n, r = a, min(b, a - b)
         if r == 0:
             return 1
         if r < 0:
-            r = b
+            r = max(b, a - b)
+            if r < 0:
+                return 0
 
         num = functools.reduce(operator.mul, range(n, n - r, -1), 1)
         den = math.factorial(r)


### PR DESCRIPTION
The old code gave an incorrect result for A < B ≤ 2·A and an error for B < 0.  This fixes `.c A B` to be defined for all integers A, B consistently with M.J. Kronenburg, “The Binomial Coefficient for Negative Arguments” (2011), https://arxiv.org/abs/1105.3689.