### PR TITLE
Made else statement auto deindent

### DIFF
--- a/data.py
+++ b/data.py
@@ -24,7 +24,7 @@ c_to_s = {
     'W': ('while {0}:{1}', 1),
     '#': ('while True:\n try:{0}\n except Exception:\n  break', 0, 1),
     '.V': ('for b in infinite_iterator({0}):{1}', 1),
-    '.?': ('else:{0}', 0),
+    'else': ('else:{0}', 0),
 }
 
 # Arbitrary format operators - use for assignment, infix, etc.
@@ -181,6 +181,7 @@ replacements = {
     'L': [['D', 'y', 'b', 'R'], ['D', "'", 'b', 'R'], ],
     'M': [['D', 'g', 'G', 'H', 'R'], ['D', 'n', 'G', 'H', 'R'], ],
     '.N': [['D', ':', 'N', 'T', 'Y', 'R'], ['D', 'X', 'N', 'T', 'Y', 'R'], ],
+    '.?': [[')', 'else'], ],
 }
 
 rotate_back_replacements = ('V',)


### PR DESCRIPTION
The else statement `.?` right now requires you to manually deindent with `)`'s or `;`. However, there is no need to make them deindent that final level, as that is already unambiguous.

I made `.?` a replacement parse that adds a `)` before the else. This lets you do things like `IQ1.?2`. Even in the case where you want to deindent multiple layers with a `;` and then do an else, it only adds an extra blank line, and doesn't add any extra chars: `IQVQN;.?_1`.

This is  a change to `.?`, not `I`, so it'll work for all the other control structures else works with.