### PR TITLE
Moved factorial to *F

### DIFF
--- a/data.py
+++ b/data.py
@@ -153,7 +153,6 @@ c_to_f = {
     '.+': ('deltas', 1),
     '.:': ('substrings', 2),
     '.{': ('Pset', 1),
-    '.!': ('factorial', 1),
     '.[': ('pad', 3),
 }
 

--- a/macros.py
+++ b/macros.py
@@ -183,14 +183,15 @@ environment['repeat'] = repeat
 
 # F on binary function. Fold.
 def fold(func, lst):
-    if not lst:
-        # '*'
-        if func == environment[c_to_f['*'][0]]:
+    if func == environment[c_to_f['*'][0]]:
+        if not lst:
             return 1
-        else:
-            return 0
-    else:
-        return reduce2(func, lst)
+        if not is_col(lst): 
+            return factorial(lst)
+
+    if not lst:
+        return 0
+    return reduce2(func, lst)
 environment['fold'] = fold
 
 


### PR DESCRIPTION
There's already some special casing for `*` in `F`, so I went all the way and replaced `.!` with `*F`. For example: you can `*FT`, or `*F12.345` which calls the existing factorial macro. Not only does this clear up a char for later use, but it also makes mapping factorial much easier like: `*MT` for a list of factorials `[0,10)`.