### PR TITLE
Import ABC classes from collections.abc to prevent Deprecation warning

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -1,6 +1,6 @@
 import binascii
 import cmath
-import collections
+import collections.abc
 import copy
 import datetime
 import fractions
@@ -27,15 +27,15 @@ def is_num(a):
 
 
 def is_seq(a):
-    return isinstance(a, collections.Sequence)
+    return isinstance(a, collections.abc.Sequence)
 
 
 def is_col(a):
-    return isinstance(a, collections.Iterable)
+    return isinstance(a, collections.abc.Iterable)
 
 
 def is_hash(a):
-    return isinstance(a, collections.Hashable)
+    return isinstance(a, collections.abc.Hashable)
 
 
 def is_lst(a):


### PR DESCRIPTION
This fixes #259.

Problem was: In Python 3.3 the abstract classes `Sequence`, `Hashable` and `Iterable` were moved to the `collections.abc` module. For backwards compatibility they were still accessable via the `collections` module. In Python 3.8 they want to break this backwards compatibility, so they added a Deprecation warning in Python 3.7, which crashes the program when the Pyth code runs with the `--safe` flag. Heroku upgraded their servers to Python 3.7 a few days ago, which introduced this error.

Notice: my quick fix only works in Python >= 3.3.